### PR TITLE
Updated event_severity_level notes

### DIFF
--- a/source/schema/entities/event_derived.csv
+++ b/source/schema/entities/event_derived.csv
@@ -1,5 +1,5 @@
 ﻿"Field Name", "Example Values", "Field Type", "Notes"
 "event_action","authenticate, change, alert, network","keyword","This field has been deprecated. Message categorization uses the gl2_event_type_code field."
 "event_outcome","success, failure","keyword",
-"event_severity","critical, high, medium, low, informational","keyword",
-"event_severity_level","1-5","byte","Numeric representation of the severity rating of the source message:  1 = Critical, 2 = High, 3 = Medium, 4 = Low, 5 = Informational"
+"event_severity","critical, high, medium, low, informational","keyword","This will be added by Illuminate Core if only the event_severity_level is defined. This can be mapped from vendor severity levels that do not use the same severity definitions."
+"event_severity_level","1-5","byte","Numeric representation of the severity rating of the source message:  5 = Critical, 4 = High, 3 = Medium, 2 = Low, 1 = Informational. This will be added by Illuminate core when only event_severity is defined."


### PR DESCRIPTION
Closes #38 

Updated definition for `event_severity` and `event_severity_level` fields
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

