### PR TITLE
Bump conf.py version

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2015-2023 Graylog, Inc'
 # author = 'Nick Carstensen'
 
 # The full version, including alpha/beta/rc tags
-release = '3.4'
+release = '3.5'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Notes for Reviewers

Bump conf.py version to 3.5
- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

